### PR TITLE
Check if content property is returned as an object

### DIFF
--- a/views/partials/query-source-test.php
+++ b/views/partials/query-source-test.php
@@ -90,7 +90,10 @@ set_up_query_test(test, endpoint, function(data){
     if(props.content && props.category) {
       if($.inArray("micropub", props.category) >= 0 
         && $.inArray("test", props.category)
-        && props.content[0] == "Test of querying the endpoint for the source content") {
+        && (typeof props.content[0] === 'object' && props.content[0] !== null) ?
+         props.content[0].value == "Test of querying the endpoint for the source content" :
+         props.content[0] == "Test of querying the endpoint for the source content"
+      ) {
         passed_body = true;
       }
     }

--- a/views/server-tests/802.php
+++ b/views/server-tests/802.php
@@ -96,6 +96,8 @@ set_up_query_test(test, endpoint, function(data){
     if(props.content && !props.access_token) {
       if(props.content[0] == "Testing accepting access token in post body") {
         passed_body = true;
+      } else if (props.content[0] && props.content[0].value && props.content[0].value == "Testing accepting access token in post body") {
+        passed_body = true;
       }
     }
   }


### PR DESCRIPTION
Absolutely not tested, but should fix #81 

But test 802 requires the same fix. Will make another pull request

