### PR TITLE
Make implementation-features table overflow scroll

### DIFF
--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -120,6 +120,8 @@ section.content textarea {
 
 .implementation-features {
   margin: 1em 0;
+  display: block;
+  overflow: scroll;
 }
 .implementation-features td {
   padding: 2px 4px;


### PR DESCRIPTION
Thanks for the site!

Without this change, the table overflow bleeds out of its parent div. 

I tested these changes by editing the styles in my browser.

<img width="806" alt="Screenshot 2021-05-12 at 18 03 47" src="https://user-images.githubusercontent.com/4623769/118015678-75318c80-b34c-11eb-8bf1-ef8af3f493e1.png">
